### PR TITLE
Fix damage editor not saving properties

### DIFF
--- a/Assets/Scenes/Chris Dev Scene.unity
+++ b/Assets/Scenes/Chris Dev Scene.unity
@@ -302,12 +302,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
---- !u!4 &805382252 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8633598789061193743, guid: d23cfcb9d00038f44831cb8873b5af50,
-    type: 3}
-  m_PrefabInstance: {fileID: 8633598789043070839}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &881292979
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -377,18 +371,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: de97166905607c84787d582256c553b3, type: 3}
---- !u!114 &1033130164 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8633598789058886659, guid: d23cfcb9d00038f44831cb8873b5af50,
-    type: 3}
-  m_PrefabInstance: {fileID: 8633598789043070839}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1070830553
 GameObject:
   m_ObjectHideFlags: 0
@@ -565,28 +547,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1530951060 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 9153037211866373910, guid: d23cfcb9d00038f44831cb8873b5af50,
-    type: 3}
-  m_PrefabInstance: {fileID: 8633598789043070839}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1530951065
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1530951060}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 433eab5279560814a8ba660aa01218f7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  ammoFillImage: {fileID: 1033130164}
-  firingInformation: {fileID: 11400000, guid: 645e9b639595e28428713ffcb49dba2e, type: 2}
-  fireZone: {fileID: 805382252}
-  baseDamage: {fileID: 11400000, guid: 0b3a3959424099a45b41164acbfbfab8, type: 2}
 --- !u!1 &2137104001
 GameObject:
   m_ObjectHideFlags: 0
@@ -1545,39 +1505,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Player Tank
-      objectReference: {fileID: 0}
-    - target: {fileID: 8454741730612689704, guid: d23cfcb9d00038f44831cb8873b5af50,
-        type: 3}
-      propertyPath: baseDamage
-      value: 
-      objectReference: {fileID: 11400000, guid: 0b3a3959424099a45b41164acbfbfab8,
-        type: 2}
-    - target: {fileID: 8454741730612689704, guid: d23cfcb9d00038f44831cb8873b5af50,
-        type: 3}
-      propertyPath: turretRotation
-      value: 
-      objectReference: {fileID: 11400000, guid: 025c2c61a5a7dcf409ed531ed46669b8,
-        type: 2}
-    - target: {fileID: 8454741730612689704, guid: d23cfcb9d00038f44831cb8873b5af50,
-        type: 3}
-      propertyPath: damage.SplashDamageInformation.HasSplashDamage
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8454741730612689704, guid: d23cfcb9d00038f44831cb8873b5af50,
-        type: 3}
-      propertyPath: damage.SplashDamageInformation.HasSplashDamageRolloff
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8633598788674284632, guid: d23cfcb9d00038f44831cb8873b5af50,
-        type: 3}
-      propertyPath: playerMovement
-      value: 
-      objectReference: {fileID: 11400000, guid: a525e39d52a1397469481d35d57cd485,
-        type: 2}
-    - target: {fileID: 8633598789196614146, guid: d23cfcb9d00038f44831cb8873b5af50,
-        type: 3}
-      propertyPath: lookingAtIgnoreLayerMask.m_Bits
-      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 9116554923332464521, guid: d23cfcb9d00038f44831cb8873b5af50,
         type: 3}

--- a/Assets/Scriptable Objects/Player/Cannon Damage.asset
+++ b/Assets/Scriptable Objects/Player/Cannon Damage.asset
@@ -15,11 +15,11 @@ MonoBehaviour:
   DamageFrom: 0
   DirectDamage: 10
   SplashDamage:
-    HasSplashDamage: 0
-    SplashRadius: 0
-    SplashDamagePercentage: 0
-    HasSplashDamageRolloff: 0
+    HasSplashDamage: 1
+    SplashRadius: 2
+    SplashDamagePercentage: 0.5
+    HasSplashDamageRolloff: 1
     MinRadiusPercentageRolloff: 0
-    MaxRadiusPercentageRolloff: 0
-    MinRadiusDamagePercentageRolloff: 0
+    MaxRadiusPercentageRolloff: 1
+    MinRadiusDamagePercentageRolloff: 1
     MaxRadiusDamagePercentageRolloff: 0

--- a/Assets/Scripts/Combat/Editor/DamageEditor.cs
+++ b/Assets/Scripts/Combat/Editor/DamageEditor.cs
@@ -6,79 +6,96 @@ namespace CwispyStudios.TankMania.Combat
   [CustomEditor(typeof(Damage))]
   public class DamageEditor : Editor
   {
+    SerializedProperty splashDamage;
+
+    SerializedProperty hasSplashDamage;
+    SerializedProperty splashRadius;
+    SerializedProperty splashDamagePercentage;
+    SerializedProperty hasSplashDamageRolloff;
+    SerializedProperty minRadiusPercentageRolloff;
+    SerializedProperty maxRadiusPercentageRolloff;
+    SerializedProperty minRadiusDamagePercentageRolloff;
+    SerializedProperty maxRadiusDamagePercentageRolloff;
+
+    private void OnEnable()
+    {
+      splashDamage = serializedObject.FindProperty(nameof(SplashDamage));
+
+      hasSplashDamage = splashDamage.FindPropertyRelative(nameof(SplashDamage.HasSplashDamage));
+      splashRadius = splashDamage.FindPropertyRelative(nameof(SplashDamage.SplashRadius));
+      splashDamagePercentage = splashDamage.FindPropertyRelative(nameof(SplashDamage.SplashDamagePercentage));
+      hasSplashDamageRolloff = splashDamage.FindPropertyRelative(nameof(SplashDamage.HasSplashDamageRolloff));
+      minRadiusPercentageRolloff = splashDamage.FindPropertyRelative(nameof(SplashDamage.MinRadiusPercentageRolloff));
+      maxRadiusPercentageRolloff = splashDamage.FindPropertyRelative(nameof(SplashDamage.MaxRadiusPercentageRolloff));
+      minRadiusDamagePercentageRolloff = splashDamage.FindPropertyRelative(nameof(SplashDamage.MinRadiusDamagePercentageRolloff));
+      maxRadiusDamagePercentageRolloff = splashDamage.FindPropertyRelative(nameof(SplashDamage.MaxRadiusDamagePercentageRolloff));
+    }
+
     public override void OnInspectorGUI()
     {
       DrawDefaultInspector();
 
-      Damage damage = (Damage)target;
-      SplashDamage splashDamage = damage.SplashDamage;
+      serializedObject.Update();
 
       EditorGUILayout.Space();
 
       EditorStyles.label.fontStyle = FontStyle.Bold;
-      splashDamage.HasSplashDamage = 
-        EditorGUILayout.Toggle("Splash Damage", splashDamage.HasSplashDamage);
+      hasSplashDamage.boolValue = EditorGUILayout.BeginToggleGroup("Splash Damage", hasSplashDamage.boolValue);
       EditorStyles.label.fontStyle = FontStyle.Normal;
 
-      if (splashDamage.HasSplashDamage)
-      {
-        EditorGUI.indentLevel = 1;
+      EditorGUI.indentLevel = 1;
 
-        splashDamage.SplashRadius = 
-          EditorGUILayout.Slider("Radius", splashDamage.SplashRadius, 0f, 50f);
-        splashDamage.SplashDamagePercentage = 
-          EditorGUILayout.Slider("Damage %", splashDamage.SplashDamagePercentage, 0f, 1f);
+      splashRadius.floatValue = EditorGUILayout.Slider("Radius", splashRadius.floatValue, 0f, 50f);
+      splashDamagePercentage.floatValue = EditorGUILayout.Slider("Damage %", splashDamagePercentage.floatValue, 0f, 1f);
 
-        EditorGUILayout.Space();
+      EditorGUILayout.Space();
 
-        splashDamage.HasSplashDamageRolloff = 
-          EditorGUILayout.Toggle(
-            new GUIContent("Damage Rolloff", "Allows damage to attenuate based on how close the projectile landed to the object."), 
-            splashDamage.HasSplashDamageRolloff
-            );
+      hasSplashDamageRolloff.boolValue = EditorGUILayout.BeginToggleGroup(
+          new GUIContent("Damage Rolloff", "Allows damage to attenuate based on how close the projectile landed to the object."),
+          hasSplashDamageRolloff.boolValue
+        );
 
-        if (splashDamage.HasSplashDamageRolloff)
-        {
-          EditorGUI.indentLevel = 2;
+      EditorGUILayout.EndToggleGroup();
 
-          EditorStyles.label.fontStyle = FontStyle.Bold;
-          EditorGUILayout.LabelField("Radius Cutoff");
-          EditorStyles.label.fontStyle = FontStyle.Normal;
+      EditorGUI.indentLevel = 2;
 
-          splashDamage.MinRadiusPercentageRolloff =
-            EditorGUILayout.Slider(
-              new GUIContent("Min Radius %", "Percentage distance from the original radius the rolloff starts."),
-              splashDamage.MinRadiusPercentageRolloff,
-              0f, splashDamage.MaxRadiusPercentageRolloff
-            );
+      EditorStyles.label.fontStyle = FontStyle.Bold;
+      EditorGUILayout.LabelField("Radius Cutoff");
+      EditorStyles.label.fontStyle = FontStyle.Normal;
 
-          splashDamage.MaxRadiusPercentageRolloff =
-            EditorGUILayout.Slider(
-              new GUIContent("Max Radius %", "Percentage distance from the original radius the rolloff ends."),
-              splashDamage.MaxRadiusPercentageRolloff,
-              splashDamage.MinRadiusPercentageRolloff, 1f);
+      minRadiusPercentageRolloff.floatValue = EditorGUILayout.Slider(
+          new GUIContent("Min Radius %", "Percentage distance from the original radius the rolloff starts."),
+          minRadiusPercentageRolloff.floatValue,
+          0f, maxRadiusPercentageRolloff.floatValue
+        );
 
-          EditorStyles.label.fontStyle = FontStyle.Bold;
-          EditorGUILayout.LabelField("Damage Percentages of Radius");
-          EditorStyles.label.fontStyle = FontStyle.Normal;
+      maxRadiusPercentageRolloff.floatValue = EditorGUILayout.Slider(
+          new GUIContent("Max Radius %", "Percentage distance from the original radius the rolloff ends."),
+          maxRadiusPercentageRolloff.floatValue,
+          minRadiusPercentageRolloff.floatValue, 1f
+        );
 
-          splashDamage.MinRadiusDamagePercentageRolloff =
-            EditorGUILayout.Slider(
-              new GUIContent("Min Damage %", "Percentage damage dealt where the rolloff starts."),
-              splashDamage.MinRadiusDamagePercentageRolloff,
-              0f, 1f
-              );
+      EditorStyles.label.fontStyle = FontStyle.Bold;
+      EditorGUILayout.LabelField("Damage Percentages of Radius");
+      EditorStyles.label.fontStyle = FontStyle.Normal;
 
-          splashDamage.MaxRadiusDamagePercentageRolloff =
-            EditorGUILayout.Slider(
-              new GUIContent("Max Damage %", "Percentage damage dealt where the rolloff ends."),
-              splashDamage.MaxRadiusDamagePercentageRolloff,
-              0f, 1f
-              );
+      minRadiusDamagePercentageRolloff.floatValue = EditorGUILayout.Slider(
+          new GUIContent("Min Damage %", "Percentage damage dealt where the rolloff starts."),
+          minRadiusDamagePercentageRolloff.floatValue,
+          0f, 1f
+        );
 
-          EditorGUI.indentLevel = 0;
-        }
-      }
+      maxRadiusDamagePercentageRolloff.floatValue = EditorGUILayout.Slider(
+          new GUIContent("Max Damage %", "Percentage damage dealt where the rolloff ends."),
+          maxRadiusDamagePercentageRolloff.floatValue,
+          0f, 1f
+        );
+
+      EditorGUI.indentLevel = 0;
+
+      EditorGUILayout.EndToggleGroup();
+
+      serializedObject.ApplyModifiedProperties();
     }
   }
 }


### PR DESCRIPTION
Damage editor now uses serializedObject and serializedProperty rather than target to display and save changes in the inspector.

How to reproduce bug: Make a change on any SplashDamage variable in the Cannon Damage Scriptable Object asset, check if the .asset file gets saved by seeing if git tracks any changes on the file. Changing the direct damage variable will update any changed property in SplashDamage in the actual file, but only changing SplashDamage properties will not save the properties and it will be lost, especially when committing your changes. 